### PR TITLE
Fix console errors relating to incorrect grid item props

### DIFF
--- a/lib/components/HomeBox.js
+++ b/lib/components/HomeBox.js
@@ -29,7 +29,7 @@ const HomeBox = ({ classes, name, children }) => (
       alignItems={'center'}
       spacing={24}
     >
-      <Grid item xs={12} md={8} lg={6} justify={'center'} spacing={16}>
+      <Grid item xs={12} md={8} lg={6}>
         <Card>
           <CardHeader
             className={classes.homeboxHeader}

--- a/lib/components/Page.js
+++ b/lib/components/Page.js
@@ -28,7 +28,7 @@ const Page = ({ classes, header, footer, children }) => (
       spacing={24}
       className={classes.gridContainer}
     >
-      <Grid item xs={12} md={10} justify={'center'} spacing={16}>
+      <Grid item xs={12} md={10}>
         {children}
       </Grid>
     </Grid>


### PR DESCRIPTION
The Grid component from Material UI cannot take spacing and justify props when the item prop is passed (only when the container prop is passed). This was causing a console error.