### PR TITLE
Add helper functions for downloading tables and charts

### DIFF
--- a/lib/helpers/downloadSVG.js
+++ b/lib/helpers/downloadSVG.js
@@ -1,0 +1,16 @@
+import FileSaver from 'file-saver';
+
+const downloadSVG = ({ svgNode, filenameStem }) => {
+  if (!svgNode) {
+    console.info('Nothing to download.');
+    return;
+  }
+
+  const contentString = svgNode.outerHTML;
+  const blob = new Blob([contentString], {
+    type: 'application/svg+xml',
+  });
+  FileSaver.saveAs(blob, `${filenameStem}.svg`);
+};
+
+export default downloadSVG;

--- a/lib/helpers/downloadTable.js
+++ b/lib/helpers/downloadTable.js
@@ -1,0 +1,84 @@
+import FileSaver from 'file-saver';
+
+const UNEXPECTED_FORMAT =
+  'Unexpected format. Supported options are csv, tsv and json.';
+
+const pick = (object, keys) => {
+  return keys.reduce(function(o, k) {
+    o[k] = object[k];
+    return o;
+  }, {});
+};
+
+const quoteIfString = d => (typeof d === 'string' ? `"${d}"` : d);
+
+const asJSONString = ({ rows, headerMap }) => {
+  const headerKeys = headerMap.map(header => header.key);
+  const rowsHeadersOnly = rows.map(row => pick(row, headerKeys));
+  return JSON.dumps(rowsHeadersOnly);
+};
+
+const asCSVString = ({ rows, headerMap }) => {
+  const headerKeys = headerMap.map(header => header.key);
+  const headerLabels = headerMap.map(header => header.label);
+  const separator = ',';
+  const lineSeparator = '\n';
+  const headersString = headerLabels.map(d => quoteIfString(d)).join(separator);
+  const rowsArray = rows.map(row =>
+    headerKeys.map(headerKey => quoteIfString(row[headerKey])).join(separator)
+  );
+  return [headersString, ...rowsArray].join(lineSeparator);
+};
+
+const asTSVString = ({ rows, headerMap }) => {
+  const headerKeys = headerMap.map(header => header.key);
+  const headerLabels = headerMap.map(header => header.label);
+  const separator = '\t';
+  const lineSeparator = '\n';
+  const headersString = headerLabels.join(separator);
+  const rowsArray = rows.map(row =>
+    headerKeys.map(headerKey => row[headerKey]).join(separator)
+  );
+  return [headersString, ...rowsArray].join(lineSeparator);
+};
+
+const asContentString = ({ rows, headerMap, format }) => {
+  switch (format) {
+    case 'json':
+      return asJSONString({ rows, headerMap });
+    case 'csv':
+      return asCSVString({ rows, headerMap });
+    case 'tsv':
+      return asTSVString({ rows, headerMap });
+    default:
+      throw Error(UNEXPECTED_FORMAT);
+  }
+};
+
+const asMimeType = format => {
+  switch (format) {
+    case 'json':
+      return 'application/json;charset=utf-8';
+    case 'csv':
+      return 'text/csv;charset=utf-8';
+    case 'tsv':
+      return 'text/tab-separated-values;charset=utf-8';
+    default:
+      throw Error(UNEXPECTED_FORMAT);
+  }
+};
+
+const downloadTable = ({ rows, headerMap, format, filenameStem }) => {
+  if (!rows || rows.length === 0) {
+    console.info('Nothing to download.');
+    return;
+  }
+
+  const contentString = asContentString({ rows, headerMap, format });
+  const blob = new Blob([contentString], {
+    type: asMimeType(format),
+  });
+  FileSaver.saveAs(blob, `${filenameStem}.${format}`);
+};
+
+export default downloadTable;

--- a/lib/helpers/downloadTable.js
+++ b/lib/helpers/downloadTable.js
@@ -15,7 +15,7 @@ const quoteIfString = d => (typeof d === 'string' ? `"${d}"` : d);
 const asJSONString = ({ rows, headerMap }) => {
   const headerKeys = headerMap.map(header => header.key);
   const rowsHeadersOnly = rows.map(row => pick(row, headerKeys));
-  return JSON.dumps(rowsHeadersOnly);
+  return JSON.stringify(rowsHeadersOnly);
 };
 
 const asCSVString = ({ rows, headerMap }) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,3 +28,5 @@ export { default as HomeBox } from './components/HomeBox';
 export { default as Search } from './components/Search';
 export { default as SearchExamples } from './components/SearchExamples';
 export { default as OtUiThemeProvider } from './components/OtUiThemeProvider';
+export { default as downloadSVG } from './helpers/downloadSVG';
+export { default as downloadTable } from './helpers/downloadTable';

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@material-ui/core": "^1.4.3",
     "d3": "^5.5.0",
     "fg-loadcss": "^2.0.1",
+    "file-saver": "^1.3.8",
     "polished": "^1.9.3",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2660,6 +2660,10 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
+file-saver@^1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-1.3.8.tgz#e68a30c7cb044e2fb362b428469feb291c2e09d8"
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"


### PR DESCRIPTION
This PR:
* adds downloadTable which:
  * takes an array of row objects, an array of header keys/labels, a format/extension and a filename
  * triggers JSON, CSV or TSV download
* adds downloadSVG which:
  * takes an svg node reference in the page
  * triggers an SVG download
