### PR TITLE
Use github icon for github link

### DIFF
--- a/lib/components/Footer.js
+++ b/lib/components/Footer.js
@@ -69,7 +69,7 @@ const externalLinks = ({ version, commitHash, githubUrl }) => ({
     },
     { classes: 'fab fa-medium', url: 'https://medium.com/opentargets' },
     {
-      classes: 'fab fa-twitter-square',
+      classes: 'fab fa-github-square',
       url: 'https://github.com/opentargets',
     },
   ],


### PR DESCRIPTION
### Description
Use the CSS class `fa-github-square` to use the github icon for the github link.