### PR TITLE
Change the API of OtTables to allow for a render function

### DIFF
--- a/lib/components/OtTable.js
+++ b/lib/components/OtTable.js
@@ -102,8 +102,8 @@ class OtTable extends Component {
         <Table>
           <TableHead>
             <TableRow>
-              {columns.map(column => (
-                <TableCell key={column.key}>{column.label}</TableCell>
+              {columns.map((column, index) => (
+                <TableCell key={index}>{column.label}</TableCell>
               ))}
             </TableRow>
           </TableHead>
@@ -112,8 +112,10 @@ class OtTable extends Component {
               .slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE)
               .map((row, index) => (
                 <TableRow key={index}>
-                  {columns.map(column => (
-                    <TableCell key={column.key}>{row[column.key]}</TableCell>
+                  {columns.map((column, index) => (
+                    <TableCell key={index}>
+                      {column.key ? row[column.key] : column.renderCell(row)}
+                    </TableCell>
                   ))}
                 </TableRow>
               ))}


### PR DESCRIPTION
### Description
You can now make use of a `renderCell` function that is located in the `columns` prop of the `OtTable` component to give you more liberty in how to render a cell.