### PR TITLE
Add commaSeparate formatter for large integers

### DIFF
--- a/lib/helpers/commaSeparate.js
+++ b/lib/helpers/commaSeparate.js
@@ -1,0 +1,5 @@
+import { format } from 'd3-format';
+
+const commaSeparate = format(',');
+
+export default commaSeparate;

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,3 +31,4 @@ export { default as OtUiThemeProvider } from './components/OtUiThemeProvider';
 export { default as downloadSVG } from './helpers/downloadSVG';
 export { default as downloadTable } from './helpers/downloadTable';
 export { default as OtTable } from './components/OtTable';
+export { default as commaSeparate } from './helpers/commaSeparate';


### PR DESCRIPTION
This PR adds a simple formatter for changing eg. 12345678 to 12,345,678. It uses d3-format.