### PR TITLE
Add ListTooltip component

### DIFF
--- a/lib/components/ListTooltip.js
+++ b/lib/components/ListTooltip.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import Paper from '@material-ui/core/Paper';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import Popper from '@material-ui/core/Popper';
+import Fade from '@material-ui/core/Fade';
+import { withStyles } from '@material-ui/core/styles';
+
+const ListTooltip = ({ dataList, open, anchorEl }) => (
+  <Popper
+    open={open}
+    anchorEl={anchorEl}
+    transition
+    placement="bottom"
+    modifiers={{
+      preventOverflow: {
+        enabled: true,
+        boundariesElement: 'window',
+      },
+    }}
+  >
+    {({ TransitionProps }) => (
+      <Fade {...TransitionProps} timeout={350}>
+        <Paper>
+          <List dense>
+            {dataList.map((d, i) => (
+              <ListItem key={i}>
+                <ListItemText primary={d.label} secondary={d.value} />
+              </ListItem>
+            ))}
+          </List>
+        </Paper>
+      </Fade>
+    )}
+  </Popper>
+);
+
+export default ListTooltip;

--- a/lib/components/ListTooltip.js
+++ b/lib/components/ListTooltip.js
@@ -7,7 +7,18 @@ import Popper from '@material-ui/core/Popper';
 import Fade from '@material-ui/core/Fade';
 import { withStyles } from '@material-ui/core/styles';
 
-const ListTooltip = ({ dataList, open, anchorEl }) => (
+const styles = theme => ({
+  listitem: {
+    padding: '0.2rem 0.6rem',
+    width: '100%',
+  },
+  listitemtext: {
+    fontSize: '0.75rem',
+    minWidth: '100%',
+  },
+});
+
+const ListTooltip = ({ classes, dataList, open, anchorEl }) => (
   <Popper
     open={open}
     anchorEl={anchorEl}
@@ -25,8 +36,12 @@ const ListTooltip = ({ dataList, open, anchorEl }) => (
         <Paper>
           <List dense>
             {dataList.map((d, i) => (
-              <ListItem key={i}>
-                <ListItemText primary={d.label} secondary={d.value} />
+              <ListItem key={i} className={classes.listitem}>
+                <ListItemText
+                  primary={d.label}
+                  secondary={d.value}
+                  className={classes.listitemtext}
+                />
               </ListItem>
             ))}
           </List>
@@ -36,4 +51,4 @@ const ListTooltip = ({ dataList, open, anchorEl }) => (
   </Popper>
 );
 
-export default ListTooltip;
+export default withStyles(styles)(ListTooltip);

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,3 +32,4 @@ export { default as downloadSVG } from './helpers/downloadSVG';
 export { default as downloadTable } from './helpers/downloadTable';
 export { default as OtTable } from './components/OtTable';
 export { default as commaSeparate } from './helpers/commaSeparate';
+export { default as ListTooltip } from './components/ListTooltip';


### PR DESCRIPTION
This PR adds a tooltip for rendering a list of properties, using a material-ui Popper component.