### PR TITLE
Add sorting functionality to the OtTable component

### DIFF
--- a/lib/components/OtTable.js
+++ b/lib/components/OtTable.js
@@ -8,6 +8,7 @@ import TableFooter from '@material-ui/core/TableFooter';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
 import TablePagination from '@material-ui/core/TablePagination';
+import TableSortLabel from '@material-ui/core/TableSortLabel';
 import IconButton from '@material-ui/core/IconButton';
 import FirstPageIcon from '@material-ui/icons/FirstPage';
 import LastPageIcon from '@material-ui/icons/LastPage';
@@ -83,9 +84,27 @@ class TablePaginationActions extends Component {
 
 TablePaginationActions = withStyles(actionsStyles)(TablePaginationActions);
 
+const getComparator = (sortBy, order) => {
+  const comparatorValue = order === 'desc' ? 1 : -1;
+
+  return (a, b) => {
+    if (a[sortBy] < b[sortBy]) {
+      return comparatorValue;
+    }
+
+    if (a[sortBy] > b[sortBy]) {
+      return -comparatorValue;
+    }
+
+    return 0;
+  };
+};
+
 class OtTable extends Component {
   state = {
     page: 0,
+    sortBy: this.props.sortBy,
+    order: this.props.order,
   };
 
   handleChangePage = (event, page) => {
@@ -94,21 +113,43 @@ class OtTable extends Component {
     });
   };
 
+  selectSortColumn = sortBy => {
+    let order = 'desc';
+
+    if (this.state.sortBy === sortBy && this.state.order === 'desc') {
+      order = 'asc';
+    }
+
+    this.setState({ sortBy, order });
+  };
+
   render() {
     const { columns, data } = this.props;
+    const { sortBy, order } = this.state;
     const { page } = this.state;
+
     return (
       <Paper>
         <Table>
           <TableHead>
             <TableRow>
               {columns.map((column, index) => (
-                <TableCell key={index}>{column.label}</TableCell>
+                <TableCell key={index}>
+                  <TableSortLabel
+                    active={column.id === sortBy}
+                    direction={order}
+                    onClick={this.selectSortColumn.bind(null, column.id)}
+                  >
+                    {column.label}
+                  </TableSortLabel>
+                </TableCell>
               ))}
             </TableRow>
           </TableHead>
           <TableBody>
             {data
+              .slice()
+              .sort(getComparator(sortBy, order))
               .slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE)
               .map((row, index) => (
                 <TableRow key={index}>

--- a/lib/components/OtTable.js
+++ b/lib/components/OtTable.js
@@ -100,6 +100,12 @@ const getComparator = (sortBy, order) => {
   };
 };
 
+const tableStyles = theme => ({
+  root: {
+    overflowX: 'auto',
+  },
+});
+
 class OtTable extends Component {
   state = {
     page: 0,
@@ -124,17 +130,17 @@ class OtTable extends Component {
   };
 
   render() {
-    const { columns, data } = this.props;
+    const { columns, data, classes } = this.props;
     const { sortBy, order } = this.state;
     const { page } = this.state;
 
     return (
-      <Paper>
+      <Paper className={classes.root}>
         <Table>
           <TableHead>
             <TableRow>
-              {columns.map((column, index) => (
-                <TableCell key={index}>
+              {columns.map(column => (
+                <TableCell key={column.id}>
                   <TableSortLabel
                     active={column.id === sortBy}
                     direction={order}
@@ -153,9 +159,11 @@ class OtTable extends Component {
               .slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE)
               .map((row, index) => (
                 <TableRow key={index}>
-                  {columns.map((column, index) => (
-                    <TableCell key={index}>
-                      {column.key ? row[column.key] : column.renderCell(row)}
+                  {columns.map(column => (
+                    <TableCell key={column.id}>
+                      {column.renderCell
+                        ? column.renderCell(row)
+                        : row[column.id]}
                     </TableCell>
                   ))}
                 </TableRow>
@@ -179,4 +187,4 @@ class OtTable extends Component {
   }
 }
 
-export default OtTable;
+export default withStyles(tableStyles)(OtTable);

--- a/lib/components/OtTable.js
+++ b/lib/components/OtTable.js
@@ -101,7 +101,7 @@ const getComparator = (sortBy, order) => {
 };
 
 const tableStyles = theme => ({
-  root: {
+  tableWrapper: {
     overflowX: 'auto',
   },
 });
@@ -135,53 +135,52 @@ class OtTable extends Component {
     const { page } = this.state;
 
     return (
-      <Paper className={classes.root}>
-        <Table>
-          <TableHead>
-            <TableRow>
-              {columns.map(column => (
-                <TableCell key={column.id}>
-                  <TableSortLabel
-                    active={column.id === sortBy}
-                    direction={order}
-                    onClick={this.selectSortColumn.bind(null, column.id)}
-                  >
-                    {column.label}
-                  </TableSortLabel>
-                </TableCell>
-              ))}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {data
-              .slice()
-              .sort(getComparator(sortBy, order))
-              .slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE)
-              .map((row, index) => (
-                <TableRow key={index}>
-                  {columns.map(column => (
-                    <TableCell key={column.id}>
-                      {column.renderCell
-                        ? column.renderCell(row)
-                        : row[column.id]}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))}
-          </TableBody>
-          <TableFooter>
-            <TableRow>
-              <TablePagination
-                count={data.length}
-                onChangePage={this.handleChangePage}
-                page={page}
-                rowsPerPage={PAGE_SIZE}
-                rowsPerPageOptions={[]}
-                ActionsComponent={TablePaginationActions}
-              />
-            </TableRow>
-          </TableFooter>
-        </Table>
+      <Paper>
+        <div className={classes.tableWrapper}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                {columns.map(column => (
+                  <TableCell key={column.id}>
+                    <TableSortLabel
+                      active={column.id === sortBy}
+                      direction={order}
+                      onClick={this.selectSortColumn.bind(null, column.id)}
+                    >
+                      {column.label}
+                    </TableSortLabel>
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {data
+                .slice()
+                .sort(getComparator(sortBy, order))
+                .slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE)
+                .map((row, index) => (
+                  <TableRow key={index}>
+                    {columns.map(column => (
+                      <TableCell key={column.id}>
+                        {column.renderCell
+                          ? column.renderCell(row)
+                          : row[column.id]}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+            </TableBody>
+          </Table>
+        </div>
+        <TablePagination
+          component="div"
+          count={data.length}
+          onChangePage={this.handleChangePage}
+          page={page}
+          rowsPerPage={PAGE_SIZE}
+          rowsPerPageOptions={[]}
+          ActionsComponent={TablePaginationActions}
+        />
       </Paper>
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,26 +16,6 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/runtime@7.0.0-beta.42":
-  version "7.0.0-beta.42"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.42.tgz#352e40c92e0460d3e82f49bd7e79f6cda76f919f"
-  dependencies:
-    core-js "^2.5.3"
-    regenerator-runtime "^0.11.1"
-
-"@babel/runtime@7.0.0-beta.56":
-  version "7.0.0-beta.56"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.56.tgz#cda612dffd5b1719a7b8e91e3040bd6ae64de8b0"
-  dependencies:
-    regenerator-runtime "^0.12.0"
-
-"@material-ui/icons@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-2.0.2.tgz#0150c38cda089ef284e9b4a730dfe6e88a0b5de6"
-  dependencies:
-    "@babel/runtime" "7.0.0-beta.42"
-    recompose "^0.28.0"
-
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -1336,10 +1316,6 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-change-emitter@^0.1.2:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
-
 character-entities-html4@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.2.tgz#c44fdde3ce66b52e8d321d6c1bf46101f0150610"
@@ -1725,7 +1701,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.3:
+core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
@@ -2665,7 +2641,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.1, fbjs@^0.8.16:
+fbjs@^0.8.16:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -2696,10 +2672,6 @@ file-entry-cache@^2.0.0:
   dependencies:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
-
-file-saver@^1.3.8:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-1.3.8.tgz#e68a30c7cb044e2fb362b428469feb291c2e09d8"
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -3149,10 +3121,6 @@ has@^1.0.1, has@^1.0.3:
 highlight.js@^9.12.0:
   version "9.12.0"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
-
-hoist-non-react-statics@^2.3.1:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -5926,7 +5894,7 @@ react-is@^16.4.2:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
 
-react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
+react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
@@ -6085,17 +6053,6 @@ recast@^0.13.0:
     private "~0.1.5"
     source-map "~0.6.1"
 
-recompose@^0.28.0:
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.28.2.tgz#19e679227bdf979e0d31b73ffe7ae38c9194f4a7"
-  dependencies:
-    "@babel/runtime" "7.0.0-beta.56"
-    change-emitter "^0.1.2"
-    fbjs "^0.8.1"
-    hoist-non-react-statics "^2.3.1"
-    react-lifecycles-compat "^3.0.2"
-    symbol-observable "^1.0.4"
-
 recursive-readdir@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.1.tgz#90ef231d0778c5ce093c9a48d74e5c5422d13a99"
@@ -6131,13 +6088,9 @@ regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
-regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
+regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-
-regenerator-runtime@^0.12.0:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -6959,7 +6912,7 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@^1.0.4, symbol-observable@^1.1.0:
+symbol-observable@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 


### PR DESCRIPTION
### Description
This PR adds sorting by column to the `OtTable` component. You can change to sort by another column just by clicking on another column header. You can toggle by ascending or descending sorting by clicking the same column. Also, some minor styling has been added to make the table contents scroll horizontally if they are bigger than their container.