### PR TITLE
Add tooltip support

### DIFF
--- a/lib/components/OtTable.js
+++ b/lib/components/OtTable.js
@@ -8,11 +8,14 @@ import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
 import TablePagination from '@material-ui/core/TablePagination';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
+import Tooltip from '@material-ui/core/Tooltip';
+import Badge from '@material-ui/core/Badge';
 import IconButton from '@material-ui/core/IconButton';
 import FirstPageIcon from '@material-ui/icons/FirstPage';
 import LastPageIcon from '@material-ui/icons/LastPage';
 import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
+import HelpIcon from '@material-ui/icons/Help';
 
 const PAGE_SIZE = 10;
 
@@ -103,6 +106,10 @@ const tableStyles = theme => ({
   tableWrapper: {
     overflowX: 'auto',
   },
+  tooltipIcon: {
+    fontSize: '1.2rem',
+    paddingLeft: `0.6rem`,
+  },
 });
 
 class OtTable extends Component {
@@ -146,7 +153,19 @@ class OtTable extends Component {
                       direction={order}
                       onClick={this.selectSortColumn.bind(null, column.id)}
                     >
-                      {column.label}
+                      {column.tooltip ? (
+                        <Badge
+                          badgeContent={
+                            <Tooltip title={column.tooltip} placement="top">
+                              <HelpIcon className={classes.tooltipIcon} />
+                            </Tooltip>
+                          }
+                        >
+                          {column.label}
+                        </Badge>
+                      ) : (
+                        column.label
+                      )}
                     </TableSortLabel>
                   </TableCell>
                 ))}


### PR DESCRIPTION
This PR adds a small help icon with tooltip on hover, per column, but only when the column definition object contains a tooltip field.