### PR TITLE
Implement the DownloadSVGPlot component

### DIFF
--- a/lib/components/DownloadSVGPlot.js
+++ b/lib/components/DownloadSVGPlot.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { findDOMNode } from 'react-dom';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
@@ -13,9 +13,7 @@ const styles = () => ({
 });
 
 const handleSVGDownload = (svgContainer, filenameStem) => {
-  const svgNode = ReactDOM.findDOMNode(svgContainer.current).querySelector(
-    'svg'
-  );
+  const svgNode = findDOMNode(svgContainer.current).querySelector('svg');
   downloadSVG({ svgNode, filenameStem });
 };
 

--- a/lib/components/DownloadSVGPlot.js
+++ b/lib/components/DownloadSVGPlot.js
@@ -19,28 +19,20 @@ const handleSVGDownload = (svgContainer, filenameStem) => {
   downloadSVG({ svgNode, filenameStem });
 };
 
-const DownloadSVGPlot = ({
-  onSVGDownload,
-  classes,
-  svgContainer,
-  filenameStem,
-  children,
-}) => {
-  return (
-    <Paper>
-      <Grid container justify="flex-end">
-        <Grid item className={classes.buttonMargin}>
-          <Button
-            variant="outlined"
-            onClick={handleSVGDownload.bind(null, svgContainer, filenameStem)}
-          >
-            SVG
-          </Button>
-        </Grid>
+const DownloadSVGPlot = ({ classes, svgContainer, filenameStem, children }) => (
+  <Paper>
+    <Grid container justify="flex-end">
+      <Grid item className={classes.buttonMargin}>
+        <Button
+          variant="outlined"
+          onClick={handleSVGDownload.bind(null, svgContainer, filenameStem)}
+        >
+          SVG
+        </Button>
       </Grid>
-      {children}
-    </Paper>
-  );
-};
+    </Grid>
+    {children}
+  </Paper>
+);
 
 export default withStyles(styles)(DownloadSVGPlot);

--- a/lib/components/DownloadSVGPlot.js
+++ b/lib/components/DownloadSVGPlot.js
@@ -1,0 +1,28 @@
+import React, { Component } from 'react';
+import Paper from '@material-ui/core/Paper';
+import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
+import { withStyles } from '@material-ui/core/styles';
+
+const styles = () => ({
+  buttonMargin: {
+    margin: '4px',
+  },
+});
+
+const DownloadSVGPlot = ({ onSVGDownload, classes, children }) => {
+  return (
+    <Paper>
+      <Grid container justify="flex-end">
+        <Grid item className={classes.buttonMargin}>
+          <Button variant="outlined" onClick={onSVGDownload}>
+            SVG
+          </Button>
+        </Grid>
+      </Grid>
+      {children}
+    </Paper>
+  );
+};
+
+export default withStyles(styles)(DownloadSVGPlot);

--- a/lib/components/DownloadSVGPlot.js
+++ b/lib/components/DownloadSVGPlot.js
@@ -1,8 +1,10 @@
 import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import { withStyles } from '@material-ui/core/styles';
+import downloadSVG from '../helpers/downloadSVG';
 
 const styles = () => ({
   buttonMargin: {
@@ -10,12 +12,28 @@ const styles = () => ({
   },
 });
 
-const DownloadSVGPlot = ({ onSVGDownload, classes, children }) => {
+const handleSVGDownload = (svgContainer, filenameStem) => {
+  const svgNode = ReactDOM.findDOMNode(svgContainer.current).querySelector(
+    'svg'
+  );
+  downloadSVG({ svgNode, filenameStem });
+};
+
+const DownloadSVGPlot = ({
+  onSVGDownload,
+  classes,
+  svgContainer,
+  filenameStem,
+  children,
+}) => {
   return (
     <Paper>
       <Grid container justify="flex-end">
         <Grid item className={classes.buttonMargin}>
-          <Button variant="outlined" onClick={onSVGDownload}>
+          <Button
+            variant="outlined"
+            onClick={handleSVGDownload.bind(null, svgContainer, filenameStem)}
+          >
             SVG
           </Button>
         </Grid>

--- a/lib/components/DownloadSVGPlot.js
+++ b/lib/components/DownloadSVGPlot.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,3 +17,4 @@ export { default as downloadTable } from './helpers/downloadTable';
 export { default as OtTable } from './components/OtTable';
 export { default as commaSeparate } from './helpers/commaSeparate';
 export { default as ListTooltip } from './components/ListTooltip';
+export { default as DownloadSVGPlot } from './components/DownloadSVGPlot';


### PR DESCRIPTION
This PR implements the `DownloadSVGPlot` component which renders and SVG download button to download the SVG node passed in as a prop.