### PR TITLE
Add option for vertical headers and export Tooltip component

### DIFF
--- a/lib/components/OtTable.js
+++ b/lib/components/OtTable.js
@@ -117,13 +117,10 @@ const tableStyles = theme => ({
     marginRight: '4px',
   },
   tableRow: {
-    height: '30px',
+    height: '31px',
   },
   tableCell: {
-    paddingRight: '12px',
-    paddingLeft: 0,
-    minWidth: '100px',
-    whiteSpace: 'nowrap',
+    padding: '0 12px 0 0',
     '&:first-child': {
       paddingLeft: '24px',
     },
@@ -140,6 +137,10 @@ const tableStyles = theme => ({
     '&:last-child': {
       paddingRight: '24px',
     },
+  },
+  verticalHeader: {
+    writingMode: 'vertical-rl',
+    transform: 'rotate(180deg)',
   },
 });
 
@@ -187,9 +188,8 @@ class OtTable extends Component {
   };
 
   render() {
-    const { columns, data, classes } = this.props;
-    const { sortBy, order } = this.state;
-    const { page } = this.state;
+    const { columns, data, verticalHeaders, classes } = this.props;
+    const { sortBy, order, page } = this.state;
 
     return (
       <Paper>
@@ -232,6 +232,9 @@ class OtTable extends Component {
                       active={column.id === sortBy}
                       direction={order}
                       onClick={this.selectSortColumn.bind(null, column.id)}
+                      className={
+                        verticalHeaders ? classes.verticalHeader : null
+                      }
                     >
                       {column.tooltip ? (
                         <Badge

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,3 +33,4 @@ export {
 export { default as CloseButton } from './components/CloseButton';
 export { default as LabelHML } from './components/LabelHML';
 export { default as DataCircle } from './components/DataCircle';
+export { default as Tooltip } from '@material-ui/core/Tooltip';


### PR DESCRIPTION
This PR exports the `Tooltip` component and also modifies the `OtTable` component to accept a new prop `verticalHeaders` to handle vertical headers.