### PR TITLE
Add custom comparator option to OtTable columns

### DIFF
--- a/lib/components/OtTable.js
+++ b/lib/components/OtTable.js
@@ -89,7 +89,16 @@ class TablePaginationActions extends Component {
 
 TablePaginationActions = withStyles(actionsStyles)(TablePaginationActions);
 
-const getComparator = (sortBy, order) => {
+const getComparator = (columns, sortBy, order) => {
+  const column = columns.find(col => col.id === sortBy);
+
+  if (column.comparator) {
+    if (order === 'asc') {
+      return column.comparator;
+    }
+    return (a, b) => -column.comparator(a, b);
+  }
+
   const comparatorValue = order === 'desc' ? 1 : -1;
 
   return (a, b) => {
@@ -259,7 +268,7 @@ class OtTable extends Component {
             <TableBody>
               {data
                 .slice()
-                .sort(getComparator(sortBy, order))
+                .sort(getComparator(columns, sortBy, order))
                 .slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE)
                 .map((row, index) => (
                   <TableRow key={index} className={classes.tableRow}>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.23",
   "description": "Open Targets UI component library",
   "main": "build/index.js",
-  "author": "Gareth Peat",
+  "contributors": [
+    "Gareth Peat <garethpeat@gmail.com>",
+    "Alfredo Miranda <alfredo@miranda.io>"
+  ],
   "license": "Apache-2.0",
   "private": false,
   "devDependencies": {


### PR DESCRIPTION
This PR adds functionality so that `OtTable` columns can accept a custom comparator field for sorting.