### PR TITLE
Update material ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# for vim users
+*.swp

--- a/lib/components/Footer.js
+++ b/lib/components/Footer.js
@@ -101,7 +101,7 @@ const FooterLink = ({ label, url }) => (
 
 const FooterSectionHeading = ({ children }) => (
   <Grid item xs={12}>
-    <Typography variant={'subheading'} color="inherit">
+    <Typography variant="subtitle1" color="inherit">
       {children}
     </Typography>
   </Grid>

--- a/lib/components/OpenTargetsTitle.js
+++ b/lib/components/OpenTargetsTitle.js
@@ -20,7 +20,7 @@ const styles = () => ({
 const OpenTargetsTitle = ({ classes, className, name }) => {
   const titleClasses = classNames(classes.root, className);
   return (
-    <Typography className={titleClasses} variant="title" color="inherit">
+    <Typography className={titleClasses} variant="h6" color="inherit">
       <span className={classes.fat}>Open Targets </span>
       <span className={classes.thin}>{name}</span>
     </Typography>

--- a/lib/components/OtTable.js
+++ b/lib/components/OtTable.js
@@ -294,7 +294,7 @@ class OtTable extends Component {
         {message ? (
           <PlotContainerSection>
             <div align="center">
-              <Typography variant="subheading">{message}</Typography>
+              <Typography variant="subtitle1">{message}</Typography>
             </div>
           </PlotContainerSection>
         ) : null}
@@ -400,7 +400,7 @@ class OtTable extends Component {
           {!loading && data.length === 0 ? (
             <PlotContainerSection>
               <div align="center">
-                <Typography variant="subheading">(no data)</Typography>
+                <Typography variant="subtitle1">(no data)</Typography>
               </div>
             </PlotContainerSection>
           ) : null}

--- a/lib/components/OtUiThemeProvider.js
+++ b/lib/components/OtUiThemeProvider.js
@@ -13,6 +13,9 @@ const VARIANT = PRIMARY;
 const STUDY = PRIMARY;
 
 const theme = createMuiTheme({
+  typography: {
+    useNextVariants: true,
+  },
   palette: {
     primary: {
       light: lighten(0.2, PRIMARY),

--- a/lib/components/PlotContainer.js
+++ b/lib/components/PlotContainer.js
@@ -44,7 +44,7 @@ const PlotContainer = ({
     {error ? (
       <PlotContainerSection>
         <div align="center">
-          <Typography variant="subheading" color="secondary">
+          <Typography variant="subtitle1" color="secondary">
             {error.graphQLErrors.map(({ message }, i) => (
               <span key={i}>{message}</span>
             ))}

--- a/lib/components/typography/Heading.js
+++ b/lib/components/typography/Heading.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
 const Heading = ({ children }) => (
-  <Typography variant="headline">{children}</Typography>
+  <Typography variant="h5">{children}</Typography>
 );
 
 export default Heading;

--- a/lib/components/typography/PageTitle.js
+++ b/lib/components/typography/PageTitle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
 const PageTitle = ({ children }) => (
-  <Typography variant="display1">{children}</Typography>
+  <Typography variant="h4">{children}</Typography>
 );
 
 export default PageTitle;

--- a/lib/components/typography/SubHeading.js
+++ b/lib/components/typography/SubHeading.js
@@ -5,10 +5,10 @@ import Typography from '@material-ui/core/Typography';
 const SubHeading = ({ left, right }) => (
   <Grid container justify="space-between">
     <Grid item>
-      <Typography variant="subheading">{left}</Typography>
+      <Typography variant="subtitle1">{left}</Typography>
     </Grid>
     <Grid item>
-      <Typography variant="subheading">{right}</Typography>
+      <Typography variant="subtitle1">{right}</Typography>
     </Grid>
   </Grid>
 );

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     ]
   },
   "peerDependencies": {
-    "@material-ui/core": "^1.4.3",
-    "@material-ui/icons": "^2.0.2",
+    "@material-ui/core": "^3.4.0",
+    "@material-ui/icons": "^3.0.1",
     "classnames": "^2.2.6",
     "d3": "^5.5.0",
     "fg-loadcss": "^2.0.1",


### PR DESCRIPTION
This PR updates the version of material ui and some other things:

- Update @material-ui/core and @material-ui/icons to the latest version
- Replace the deprecated values for the `variant` prop of the `Typography` component according to this https://material-ui.com/style/typography/#migration-to-typography-v2
- Updated the .gitignore file