### PR TITLE
Lf table download

### DIFF
--- a/lib/components/OtUiThemeProvider.js
+++ b/lib/components/OtUiThemeProvider.js
@@ -59,6 +59,7 @@ const theme = createMuiTheme({
       root: {
         width: '32px',
         height: '32px',
+        padding: '0px',
       },
     },
     MuiTablePagination: {

--- a/lib/helpers/downloadTable.js
+++ b/lib/helpers/downloadTable.js
@@ -19,26 +19,34 @@ const asJSONString = ({ rows, headerMap }) => {
 };
 
 const asCSVString = ({ rows, headerMap }) => {
-  const headerKeys = headerMap.map(header => header.id);
-  const headerLabels = headerMap.map(header => header.label);
   const separator = ',';
   const lineSeparator = '\n';
-  const headersString = headerLabels.map(d => quoteIfString(d)).join(separator);
-  const rowsArray = rows.map(row =>
-    headerKeys.map(headerKey => quoteIfString(row[headerKey])).join(separator)
-  );
+  const headersString = headerMap
+    .map(d => quoteIfString(d.label))
+    .join(separator);
+  const rowsArray = rows.map(row => {
+    return headerMap
+      .map(header => {
+        return quoteIfString(
+          header.export ? header.export(row) : row[header.id]
+        );
+      })
+      .join(separator);
+  });
   return [headersString, ...rowsArray].join(lineSeparator);
 };
 
 const asTSVString = ({ rows, headerMap }) => {
-  const headerKeys = headerMap.map(header => header.id);
-  const headerLabels = headerMap.map(header => header.label);
   const separator = '\t';
   const lineSeparator = '\n';
-  const headersString = headerLabels.join(separator);
-  const rowsArray = rows.map(row =>
-    headerKeys.map(headerKey => row[headerKey]).join(separator)
-  );
+  const headersString = headerMap.map(d => d.label).join(separator);
+  const rowsArray = rows.map(row => {
+    return headerMap
+      .map(header => {
+        return header.export ? header.export(row) : row[header.id];
+      })
+      .join(separator);
+  });
   return [headersString, ...rowsArray].join(lineSeparator);
 };
 


### PR DESCRIPTION
In the current version of OtTable, when downloading in CSV/TSV format the content for a column is matched by id. 
This doesn't work for nested fields in the data structure, resulting in a `[Object object]` string being inserted in the downloaded file for that cell.
This is also what happens when sorting columns, where fortunately we can specify a `comparator` function.

Similarly, I've added the option for an `export` function which specify what to include for that column in the downloaded file. If there is an `export` function OtTable will use that, and try to match by `id` otherwise. For example:

```
const columns = [
  {
     id: 'disease',
     label: 'Disease',
     renderCell: d => d.disease.name,
     comparator: generateComparatorFromAccessor(d => d.disease.name),
     export: d => d.disease.name,
  }
```
