### PR TITLE
Table download labels and JSON options

### DIFF
--- a/lib/components/OtTable.js
+++ b/lib/components/OtTable.js
@@ -176,6 +176,9 @@ const tableStyles = theme => ({
     transform: 'rotate(180deg)',
     whiteSpace: 'nowrap',
   },
+  downloadHeader: {
+    marginTop: '7px',
+  },
 });
 
 class OtTable extends Component {
@@ -265,6 +268,11 @@ class OtTable extends Component {
         center={center}
         right={
           <Grid container justify="flex-end" spacing={8}>
+            <Grid item>
+              <Typography variant="caption" className={classes.downloadHeader}>
+                Download table as
+              </Typography>
+            </Grid>
             <Grid item>
               <Button
                 variant="outlined"

--- a/lib/helpers/downloadTable.js
+++ b/lib/helpers/downloadTable.js
@@ -5,7 +5,8 @@ const UNEXPECTED_FORMAT =
 
 const pick = (object, keys) => {
   return keys.reduce(function(o, k) {
-    o[k] = object[k];
+    // take into account optional export() function, which takes precedence as per other download formats
+    o[k.id] = k.export ? k.export(object) : object[k.id];
     return o;
   }, {});
 };
@@ -13,8 +14,8 @@ const pick = (object, keys) => {
 const quoteIfString = d => (typeof d === 'string' ? `"${d}"` : d);
 
 const asJSONString = ({ rows, headerMap }) => {
-  const headerKeys = headerMap.map(header => header.id);
-  const rowsHeadersOnly = rows.map(row => pick(row, headerKeys));
+  // use the full headerMap which contain optional export() function for each header
+  const rowsHeadersOnly = rows.map(row => pick(row, headerMap));
   return JSON.stringify(rowsHeadersOnly);
 };
 


### PR DESCRIPTION
Short PR to address two issues in the POC QC UX review:
1. Add text label beside download buttons - "Download table as ..."
2. Add "Phase", "Status", "Source", and "Mechanism of Action" data to JSON export

Buttons label is straightforward (extra text doesn't clash with current genetics platform tables).

JSON export (point 2.) now takes into account the optional `export` callback. This is consistent with the CSV and TSV download functions. The issue was for example with the new drugs table where we pass all crossfilter data to the table (and then use the `renderCell()`, `comparator()` and `export()` options). This causes the current json download to only match few fields, but returning the full field object, hence not matching the table structure.

If the `export` option is not defined, it defaults back to standard implementation: I tested it with a genetics portal table and works correctly.