### PR TITLE
Added option for 2-tier table header

### DIFF
--- a/lib/components/OtTableRF.js
+++ b/lib/components/OtTableRF.js
@@ -158,6 +158,13 @@ const tableStyles = theme => ({
       paddingRight: '24px',
     },
   },
+  tableCellSpanHeader: {
+    borderLeft: '1px solid #E0E0E0',
+    paddingLeft: '5px',
+    '&:first-child': {
+      borderLeft: 'none',
+    },
+  },
   tableCellHeaderVertical: {
     textAlign: 'center',
     verticalAlign: 'bottom',
@@ -223,6 +230,7 @@ class OtTableRF extends Component {
       message,
       filters,
       pageSize,
+      headerGroups,
     } = this.props;
     const { sortBy, order, page } = this.state;
     const filterRow = filters ? (
@@ -252,6 +260,22 @@ class OtTableRF extends Component {
           <div className={classes.tableWrapper}>
             <Table>
               <TableHead>
+                {headerGroups ? (
+                  <TableRow>
+                    {headerGroups.map((g, i) => (
+                      <TableCell
+                        colSpan={g.colspan}
+                        key={i}
+                        className={classNames(
+                          classes.tableCellHeader,
+                          classes.tableCellSpanHeader
+                        )}
+                      >
+                        {g.label}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ) : null}
                 <TableRow>
                   {columns.map(column => (
                     <TableCell


### PR DESCRIPTION
I've updated OTTableRF with optional configuration for 2-tier table headers.
It can be specified/configured as:
```
       <OtTableRF
          headerGroups={[
            {colspan:1, label:''},
            {colspan:3, label:'Trial information'},
            {colspan:4, label:'Drug information'},
          ]}
        />
```

The `headerGroups` param is optional, so won't affect tables where it's not specified.