### PR TITLE
Override MuiExpansionPanel styling

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -102,6 +102,31 @@ const theme = createMuiTheme({
         color: '#C94C52',
       },
     },
+    MuiExpansionPanelSummary: {
+      root: {
+        padding: 0,
+        minHeight: 0,
+        '&$expanded': {
+          minHeight: 0,
+        },
+      },
+      content: {
+        margin: 0,
+        '&$expanded': {
+          margin: 0,
+        },
+      },
+      expanded: {
+        margin: 0,
+        minHeight: 0,
+      },
+    },
+    MuiExpansionPanelDetails: {
+      root: {
+        padding: 0,
+        paddingRight: '32px',
+      },
+    },
   },
 });
 


### PR DESCRIPTION
This PR overrides styling of the `MuiExpansionPanel` for use in the display of credible sets.