### PR TITLE
Tweak how themes work

### DIFF
--- a/lib/components/OtUiThemeProvider.js
+++ b/lib/components/OtUiThemeProvider.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { MuiThemeProvider } from '@material-ui/core/styles';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 
 import defaultTheme from '../theme';
 import setupIcons from '../icons/setupIcons';
@@ -12,7 +12,7 @@ class OtUiThemeProvider extends React.Component {
   render() {
     const { children, theme = defaultTheme } = this.props;
     return (
-      <MuiThemeProvider theme={theme}>
+      <MuiThemeProvider theme={createMuiTheme(theme)}>
         <CssBaseline />
         {children}
       </MuiThemeProvider>

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -1,4 +1,3 @@
-import { createMuiTheme } from '@material-ui/core/styles';
 import { lighten, darken } from 'polished';
 
 const PRIMARY = '#3489ca'; // '#7b196a'; // '#0091eb';
@@ -8,7 +7,7 @@ const GENE = PRIMARY;
 const VARIANT = PRIMARY;
 const STUDY = PRIMARY;
 
-const theme = createMuiTheme({
+const theme = {
   shape: {
     borderRadius: 0,
   },
@@ -145,6 +144,6 @@ const theme = createMuiTheme({
       },
     },
   },
-});
+};
 
 export default theme;


### PR DESCRIPTION
Tweak how themes work so that a user only needs to create a JS object and without having to worrying about importing `createMuiTheme`.