### PR TITLE
Add initial options for server side pagination

### DIFF
--- a/lib/components/OtTableRF.js
+++ b/lib/components/OtTableRF.js
@@ -195,24 +195,30 @@ class OtTableRF extends Component {
   };
 
   handleChangePage = (event, page) => {
+    const { callPagination, pageSize } = this.props;
     this.setState({
       page,
     });
+    if (callPagination) {
+      callPagination(page, pageSize);
+    }
   };
 
   selectSortColumn = sortBy => {
-    const { reportTableSortEvent } = this.props;
-    let order = 'desc';
+    const { reportTableSortEvent, serverPagination } = this.props;
+    if (!serverPagination) {
+      let order = 'desc';
 
-    if (this.state.sortBy === sortBy && this.state.order === 'desc') {
-      order = 'asc';
+      if (this.state.sortBy === sortBy && this.state.order === 'desc') {
+        order = 'asc';
+      }
+
+      if (reportTableSortEvent) {
+        reportTableSortEvent(sortBy, order);
+      }
+
+      this.setState({ sortBy, order });
     }
-
-    if (reportTableSortEvent) {
-      reportTableSortEvent(sortBy, order);
-    }
-
-    this.setState({ sortBy, order });
   };
 
   render() {
@@ -232,6 +238,8 @@ class OtTableRF extends Component {
       pageSize,
       headerGroups,
       tableRowComponent,
+      serverPagination,
+      totalPagination,
     } = this.props;
     const { sortBy, order, page } = this.state;
     const filterRow = filters ? (
@@ -355,7 +363,10 @@ class OtTableRF extends Component {
                 {data
                   .slice()
                   .sort(getComparator(columns, sortBy, order))
-                  .slice(page * pageSize, page * pageSize + pageSize)
+                  .slice(
+                    (serverPagination ? 0 : page) * pageSize,
+                    (serverPagination ? 0 : page) * pageSize + pageSize
+                  )
                   .map((row, index) => (
                     <TableRow
                       key={index}
@@ -392,7 +403,7 @@ class OtTableRF extends Component {
           ) : null}
           <TablePagination
             component="div"
-            count={data.length}
+            count={serverPagination ? totalPagination : data.length}
             onChangePage={this.handleChangePage}
             page={page}
             rowsPerPage={pageSize}

--- a/lib/components/OtTableRF.js
+++ b/lib/components/OtTableRF.js
@@ -205,20 +205,18 @@ class OtTableRF extends Component {
   };
 
   selectSortColumn = sortBy => {
-    const { reportTableSortEvent, serverPagination } = this.props;
-    if (!serverPagination) {
-      let order = 'desc';
+    const { reportTableSortEvent } = this.props;
+    let order = 'desc';
 
-      if (this.state.sortBy === sortBy && this.state.order === 'desc') {
-        order = 'asc';
-      }
-
-      if (reportTableSortEvent) {
-        reportTableSortEvent(sortBy, order);
-      }
-
-      this.setState({ sortBy, order });
+    if (this.state.sortBy === sortBy && this.state.order === 'desc') {
+      order = 'asc';
     }
+
+    if (reportTableSortEvent) {
+      reportTableSortEvent(sortBy, order);
+    }
+
+    this.setState({ sortBy, order });
   };
 
   render() {
@@ -295,32 +293,38 @@ class OtTableRF extends Component {
                         [classes.tableCellVertical]: column.verticalHeader,
                       })}
                     >
-                      <TableSortLabel
-                        active={column.id === sortBy}
-                        direction={order}
-                        onClick={this.selectSortColumn.bind(null, column.id)}
-                        className={
-                          column.verticalHeader ? classes.verticalHeader : null
-                        }
-                      >
-                        {column.tooltip ? (
-                          <Badge
-                            badgeContent={
-                              <Tooltip
-                                title={column.tooltip}
-                                placement="top"
-                                interactive
-                              >
-                                <HelpIcon className={classes.tooltipIcon} />
-                              </Tooltip>
-                            }
-                          >
-                            {column.label}
-                          </Badge>
-                        ) : (
-                          column.label
-                        )}
-                      </TableSortLabel>
+                      {column.orderable !== false ? (
+                        <TableSortLabel
+                          active={column.id === sortBy}
+                          direction={order}
+                          onClick={this.selectSortColumn.bind(null, column.id)}
+                          className={
+                            column.verticalHeader
+                              ? classes.verticalHeader
+                              : null
+                          }
+                        >
+                          {column.tooltip ? (
+                            <Badge
+                              badgeContent={
+                                <Tooltip
+                                  title={column.tooltip}
+                                  placement="top"
+                                  interactive
+                                >
+                                  <HelpIcon className={classes.tooltipIcon} />
+                                </Tooltip>
+                              }
+                            >
+                              {column.label}
+                            </Badge>
+                          ) : (
+                            column.label
+                          )}
+                        </TableSortLabel>
+                      ) : (
+                        column.label
+                      )}
                     </TableCell>
                   ))}
                   {verticalHeaders ? (

--- a/lib/components/OtTableRF.js
+++ b/lib/components/OtTableRF.js
@@ -387,6 +387,7 @@ class OtTableRF extends Component {
                           className={classNames(classes.tableCell, {
                             [classes.tableCellVertical]: column.verticalHeader,
                           })}
+                          style={column.style}
                         >
                           {column.renderCell
                             ? column.renderCell(row)

--- a/lib/components/OtTableRF.js
+++ b/lib/components/OtTableRF.js
@@ -295,6 +295,9 @@ class OtTableRF extends Component {
                           column.verticalHeader,
                         [classes.tableCellVertical]: column.verticalHeader,
                       })}
+                      style={{
+                        width: column.width,
+                      }}
                     >
                       {column.orderable !== false ? (
                         <TableSortLabel

--- a/lib/components/OtTableRF.js
+++ b/lib/components/OtTableRF.js
@@ -195,17 +195,17 @@ class OtTableRF extends Component {
   };
 
   handleChangePage = (event, page) => {
-    const { callPagination, pageSize } = this.props;
+    const { onPageSort, pageSize } = this.props;
     this.setState({
       page,
     });
-    if (callPagination) {
-      callPagination(page, pageSize);
+    if (onPageSort) {
+      onPageSort({ page: page, pageSize: pageSize });
     }
   };
 
   selectSortColumn = sortBy => {
-    const { reportTableSortEvent } = this.props;
+    const { reportTableSortEvent, onPageSort } = this.props;
     let order = 'desc';
 
     if (this.state.sortBy === sortBy && this.state.order === 'desc') {
@@ -216,6 +216,9 @@ class OtTableRF extends Component {
       reportTableSortEvent(sortBy, order);
     }
 
+    if (onPageSort) {
+      onPageSort({ sortBy: sortBy, order: order });
+    }
     this.setState({ sortBy, order });
   };
 
@@ -236,8 +239,8 @@ class OtTableRF extends Component {
       pageSize,
       headerGroups,
       tableRowComponent,
-      serverPagination,
-      totalPagination,
+      serverSide,
+      totalRowsCount,
     } = this.props;
     const { sortBy, order, page } = this.state;
     const filterRow = filters ? (
@@ -368,8 +371,8 @@ class OtTableRF extends Component {
                   .slice()
                   .sort(getComparator(columns, sortBy, order))
                   .slice(
-                    (serverPagination ? 0 : page) * pageSize,
-                    (serverPagination ? 0 : page) * pageSize + pageSize
+                    (serverSide ? 0 : page) * pageSize,
+                    (serverSide ? 0 : page) * pageSize + pageSize
                   )
                   .map((row, index) => (
                     <TableRow
@@ -407,7 +410,7 @@ class OtTableRF extends Component {
           ) : null}
           <TablePagination
             component="div"
-            count={serverPagination ? totalPagination : data.length}
+            count={serverSide ? totalRowsCount : data.length}
             onChangePage={this.handleChangePage}
             page={page}
             rowsPerPage={pageSize}


### PR DESCRIPTION
Rough implementation of pagination for OtTableRF, tested with the evidence literature code.
Still very much in progress but would be good to get some feedback as I know we're looking at reloading queries in other parts of the platform.

Example use:
```
        const paginationCallback = (page, pageSize) => {
          this.setState({ from: (page * (pageSize || size)) });
        }
        // .....
      return(
        <OtTableRF
          loading={false}
          error={false}
          columns={columns}
          data={data.rows}
          serverPagination={true}
          totalPagination={data.textMiningCount}
          callPagination={paginationCallback}
        />
      )
```